### PR TITLE
Remove 3D view settings panel in favor of direct mode toggle

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -91,11 +91,6 @@ pub fn handle_keyboard_shortcuts(
         panels.toggle_panel(PanelId::DataSources);
     }
 
-    // 3 - Toggle 3D view
-    if keyboard.just_pressed(KeyCode::Digit3) {
-        panels.toggle_panel(PanelId::View3D);
-    }
-
     // H - Toggle help overlay
     if keyboard.just_pressed(KeyCode::KeyH) {
         panels.toggle_panel(PanelId::Help);
@@ -312,7 +307,7 @@ B     Toggle bookmarks
 M     Measurement mode
 E     Export data panel
 V     Toggle coverage tracking
-3     Toggle 3D view panel
+3     Toggle 3D view mode
 Esc   Deselect / cancel follow
 F     Follow selected aircraft
 C     Center on selected


### PR DESCRIPTION
## Summary
- Removed the egui 3D View Settings panel (`render_3d_view_panel`) and its `show_panel` state field
- The '3' key now directly toggles 3D view mode instead of opening a settings panel
- Updated help text to reflect "Toggle 3D view mode"

## Test plan
- [ ] Press '3' to verify 3D view mode toggles on/off correctly
- [ ] Verify no panel appears when pressing '3'
- [ ] Confirm help overlay shows updated "Toggle 3D view mode" text